### PR TITLE
Fix line chart name

### DIFF
--- a/results.yml
+++ b/results.yml
@@ -518,7 +518,7 @@ translations:
 
   # tools experience linechart
   - key: blocks.tools_experience_linechart
-    t: Experience Over Time
+    t: Ratios Over Time
   - key: blocks.tools_experience_linechart.description
     t: Retention, interest, usage, and awareness ratio over time.
   - key: blocks.tools_experience_linechart.note


### PR DESCRIPTION
Apparently, this can get confusing, so it probably makes sense to use a different name for the line chart.

![image](https://user-images.githubusercontent.com/4408379/206564617-88ad265a-8853-4e53-884c-992b6160daa7.png)


cc @SachaG 